### PR TITLE
Make it so the quickstart will always install fresh version on first run

### DIFF
--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -6,8 +6,6 @@
 
 set -e
 
-version="1.0.19"
-
 if [ -z $OPENSHIFT_MYSQL_DB_HOST ]
 then
     echo 1>&2
@@ -37,13 +35,15 @@ else
 fi
 
 # Download and extract Kanboard
-if [[ ! -d ${OPENSHIFT_DATA_DIR}kanboard-${version} ]]
+# If OPENSHIFT_KANBOARD_VERSION is unset we get latest, but if we have latest we get nothing
+# This ensures that new installs are up to date but updates must be done with explicit versioning
+if [[ ! -d ${OPENSHIFT_DATA_DIR}kanboard-${OPENSHIFT_KANBOARD_VERSION:=latest} ]]
 then
     cd ${OPENSHIFT_DATA_DIR}
 
-    wget http://kanboard.net/kanboard-${version}.zip
-    unzip kanboard-${version}.zip
-    mv kanboard kanboard-${version}
+    wget http://kanboard.net/kanboard-${OPENSHIFT_KANBOARD_VERSION}.zip
+    unzip kanboard-${OPENSHIFT_KANBOARD_VERSION}.zip
+    mv kanboard kanboard-${OPENSHIFT_KANBOARD_VERSION}
 
     cd - > /dev/null
 fi
@@ -56,5 +56,5 @@ then
 fi
 
 # Copy stuff in the php folder
-cp -r ${OPENSHIFT_DATA_DIR}/kanboard-${version}/* ${OPENSHIFT_REPO_DIR}php/
+cp -r ${OPENSHIFT_DATA_DIR}/kanboard-${OPENSHIFT_KANBOARD_VERSION}/* ${OPENSHIFT_REPO_DIR}php/
 cp -r ${OPENSHIFT_REPO_DIR}/.openshift/action_hooks/config.php ${OPENSHIFT_REPO_DIR}php/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ On subsequent runs it will not be modified unless the version that you wish to u
 to is explicitly specified in the OpenShift environment variable OPENSHIFT_KANBOARD_VERSION.
 To set this variable, use the following command:
 
- rhc env set OPENSHIFT_KANBOARD_VERSION=<VERSION> -a <APP NAME>
+    rhc env set OPENSHIFT_KANBOARD_VERSION=<VERSION> -a <APP NAME>
 
 Then commit and push.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,12 @@ openshift-kanboard-quickstart-app
 QuickStart for Kanboard
 
 This quickstart will set up an instance automatically.
-In order to upgrade the version, increment the version number in the .openshift/action-hooks/deploy script
+
+By default the quickstart will pull the most recent version of kanboard on first run.
+On subsequent runs it will not be modified unless the version that you wish to update
+to is explicitly specified in the OpenShift environment variable OPENSHIFT_KANBOARD_VERSION.
+To set this variable, use the following command:
+
+ rhc env set OPENSHIFT_KANBOARD_VERSION=<VERSION> -a <APP NAME>
+
+Then commit and push.


### PR DESCRIPTION
Hey Fabio,

When incrementing my version on openshift last week I had a brainwave and rewrote the versioning in the deploy hook. It now fetches 'latest' by default and uses openshift environment variables to track versioning instead of info in the file. This should make the quickstart timeless until such point as there needs to be an actual change in workflow.

I've also changed the readme to explain the new process.
